### PR TITLE
Add payment method Klarna KP and change the names for Billink and in3

### DIFF
--- a/includes/classes/Pay/Gateway/Abstract.php
+++ b/includes/classes/Pay/Gateway/Abstract.php
@@ -509,6 +509,10 @@ abstract class Pay_Gateway_Abstract extends WC_Payment_Gateway
      */
     public function process_refund($order_id, $amount = null, $reason = '')
     {
+        if ($amount <= 0) {
+            return new WP_Error('1', "Refund amount must be greater than €0.00");
+        }
+
         $order = wc_get_order($order_id);
 
         $transactionId = Pay_Helper_Transaction::getPaidTransactionIdForOrderId($order_id);

--- a/includes/classes/Pay/Gateway/Applepay.php
+++ b/includes/classes/Pay/Gateway/Applepay.php
@@ -1,0 +1,17 @@
+<?php
+
+class Pay_Gateway_Applepay extends Pay_Gateway_Abstract {
+
+    public static function getId() {
+        return 'pay_gateway_applepay';
+    }
+
+    public static function getName() {
+        return 'Apple Pay';
+    }
+
+    public static function getOptionId() {
+        return 2277;
+    }
+
+}

--- a/includes/classes/Pay/Gateway/Applepay.php
+++ b/includes/classes/Pay/Gateway/Applepay.php
@@ -2,16 +2,16 @@
 
 class Pay_Gateway_Applepay extends Pay_Gateway_Abstract {
 
-    public static function getId() {
-        return 'pay_gateway_applepay';
-    }
+  public static function getId() {
+    return 'pay_gateway_applepay';
+  }
 
-    public static function getName() {
-        return 'Apple Pay';
-    }
+  public static function getName() {
+    return 'Apple Pay';
+  }
 
-    public static function getOptionId() {
-        return 2277;
-    }
+  public static function getOptionId() {
+    return 2277;
+  }
 
 }

--- a/includes/classes/Pay/Gateway/Billink.php
+++ b/includes/classes/Pay/Gateway/Billink.php
@@ -7,7 +7,7 @@ class Pay_Gateway_Billink extends Pay_Gateway_Abstract {
     }
 
     public static function getName() {
-        return 'Billink';
+        return 'Achteraf betalen via Billink';
     }
 
     public static function getOptionId() {

--- a/includes/classes/Pay/Gateway/Capayable.php
+++ b/includes/classes/Pay/Gateway/Capayable.php
@@ -10,7 +10,7 @@ class Pay_Gateway_Capayable extends Pay_Gateway_Abstract
 
   public static function getName()
   {
-    return 'Capayable';
+    return 'in3 keer betalen, 0% rente';
   }
 
   public static function getOptionId()

--- a/includes/classes/Pay/Gateway/Klarnakp.php
+++ b/includes/classes/Pay/Gateway/Klarnakp.php
@@ -1,0 +1,17 @@
+<?php
+
+class Pay_Gateway_Klarnakp extends Pay_Gateway_Abstract {
+
+    public static function getId() {
+        return 'pay_gateway_klarnakp';
+    }
+
+    public static function getName() {
+        return 'Klarna KP';
+    }
+
+    public static function getOptionId() {
+        return 2265;
+    }
+
+}

--- a/includes/classes/Pay/Gateways.php
+++ b/includes/classes/Pay/Gateways.php
@@ -15,6 +15,7 @@ class Pay_Gateways
             'Pay_Gateway_Alipay',
             'Pay_Gateway_Amazonpay',
             'Pay_Gateway_Amex',
+            'Pay_Gateway_Applepay',
             'Pay_Gateway_Afterpay',
             'Pay_Gateway_Billink',
             'Pay_Gateway_Cartasi',

--- a/includes/classes/Pay/Gateways.php
+++ b/includes/classes/Pay/Gateways.php
@@ -37,6 +37,7 @@ class Pay_Gateways
             'Pay_Gateway_Incasso',
             'Pay_Gateway_Instore',
             'Pay_Gateway_Klarna',
+            'Pay_Gateway_Klarnakp',
             'Pay_Gateway_Maestro',
             'Pay_Gateway_Minitixsms',
             'Pay_Gateway_Mistercash',

--- a/includes/classes/Pay/Helper/Data.php
+++ b/includes/classes/Pay/Helper/Data.php
@@ -53,7 +53,7 @@ class Pay_Helper_Data
         $wpdb->query('TRUNCATE TABLE ' . $table_name_options);
 
         foreach ($paymentOptions as $paymentOption) {
-            $image = 'https://www.pay.nl/images/payment_profiles/25x25/' . $paymentOption['id'] . '.png';
+            $image = 'https://static.pay.nl/payment_profiles/25x25/' . $paymentOption['id'] . '.png';
             $wpdb->insert(
                 $table_name_options, array(
                 'id' => $paymentOption['id'],

--- a/includes/classes/Pay/Helper/Transaction.php
+++ b/includes/classes/Pay/Helper/Transaction.php
@@ -74,9 +74,14 @@ class Pay_Helper_Transaction
             throw new Pay_Exception(__('Transaction not found', ''));
         }
 
-        //order ophalen
+        # Order ophalen.
         $orderId = $transaction['order_id'];
-        $order = new WC_Order($orderId);
+        try {
+          $order = new WC_Order($orderId);
+        } catch (Exception $e) {
+          // Er is iets fout gegaan bij het ophalen van de order.
+          throw new Pay_Exception_Notice('Woocommerce could not find internal order');
+        }
         if ($status == $transaction['status']) {
             if ($status == Pay_Gateways::STATUS_CANCELED) {
                 return add_query_arg('paynl_status', Pay_Gateways::STATUS_CANCELED, $woocommerce->cart->get_checkout_url());

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.pay.nl/webshops/plugin-woocommerce
 Link: http://www.pay.nl
 Tags: paynl, paymentmethods, woocommerce, ideal, Alipay, Wechatpay, ,paypal, creditcard, mybank, sofortbanking, afterpay, mistercash, bancontact, paysafecard, clickandbuy, giropay, incasso, betaalmethoden, billink, wijncadeau, givacard, cashly, wechatpay, spraypay, tikkie, przelewy24, creditclick
 Requires at least: 3.5.1
-Stable tag: 3.3.7
+Stable tag: 3.3.8
 Tested up to: 5.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.pay.nl/webshops/plugin-woocommerce
 Link: http://www.pay.nl
 Tags: paynl, paymentmethods, woocommerce, ideal, Alipay, Wechatpay, ,paypal, creditcard, mybank, sofortbanking, afterpay, mistercash, bancontact, paysafecard, clickandbuy, giropay, incasso, betaalmethoden, billink, wijncadeau, givacard, cashly, wechatpay, spraypay, tikkie, przelewy24, creditclick
 Requires at least: 3.5.1
-Stable tag: 3.3.8
+Stable tag: 3.3.10
 Tested up to: 5.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -43,6 +43,7 @@ With Pay.nl you can add the following payment options to your website:
 * IN3 Gespreid betalen
 * Incasso
 * Instore payments (PIN)
+* Klarna KP
 * Maestro
 * Manual transfer
 * Mastercard
@@ -125,6 +126,7 @@ At the moment the plugin supports the following payment methods:
 * IN3 Gespreid betalen
 * Incasso
 * Instore payments (PIN)
+* Klarna KP
 * Maestro
 * Manual transfer
 * Mastercard
@@ -165,8 +167,15 @@ Paid accounts have better tariffs! see: [tariffs](http://pay.nl/tarieven)
 4. The iDEAL payment screen (Rabobank)
 
 == Changelog ==
-= 3.3.8 =
+= 3.3.10 =
+Add payment method Klarna KP
+Fix a bug where the full amount gets refunded after putting a 0 in the refund amount field
+Change the names of Billink and in3
+Change the payment profile icons to a static link
+= 3.3.9 =
 Added payment method Apple Pay
+= 3.3.8 =
+Better exception handling in exchange script
 = 3.3.7 =
 Added paymentmethods: Tikkie, Przelewy 24 and Creditclick
 = 3.3.6 =

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ With Pay.nl you can add the following payment options to your website:
 * Alipay
 * Amazon Pay
 * American Express (AMEX)
+* Apple Pay
 * Bancontact
 * Billink
 * Capayable
@@ -104,6 +105,7 @@ At the moment the plugin supports the following payment methods:
 * Afterpay
 * Amazon Pay
 * American Express (AMEX)
+* Apple Pay
 * Bancontact
 * Billink
 * Capayable
@@ -163,6 +165,8 @@ Paid accounts have better tariffs! see: [tariffs](http://pay.nl/tarieven)
 4. The iDEAL payment screen (Rabobank)
 
 == Changelog ==
+= 3.3.8 =
+Added payment method Apple Pay
 = 3.3.7 =
 Added paymentmethods: Tikkie, Przelewy 24 and Creditclick
 = 3.3.6 =

--- a/woocommerce-payment-paynl.php
+++ b/woocommerce-payment-paynl.php
@@ -4,7 +4,7 @@
  * Plugin Name: Woocommerce Pay.nl Payment Methods
  * Plugin URI: https://wordpress.org/plugins/woocommerce-paynl-payment-methods/
  * Description: Pay.nl payment methods for woocommerce
- * Version: 3.3.8
+ * Version: 3.3.10
  * Author: Pay.nl
  * Author URI: http://www.pay.nl
  * Requires at least: 3.5.1

--- a/woocommerce-payment-paynl.php
+++ b/woocommerce-payment-paynl.php
@@ -4,7 +4,7 @@
  * Plugin Name: Woocommerce Pay.nl Payment Methods
  * Plugin URI: https://wordpress.org/plugins/woocommerce-paynl-payment-methods/
  * Description: Pay.nl payment methods for woocommerce
- * Version: 3.3.7
+ * Version: 3.3.8
  * Author: Pay.nl
  * Author URI: http://www.pay.nl
  * Requires at least: 3.5.1


### PR DESCRIPTION
Wat moet er getest worden:

- Klarna KP correct is toegevoegd
- bug waarbij volledige bedrag wordt gerefund als er 0 wordt ingevuld.
- De namen van Billink en in3 zijn veranderd naar: "Achteraf betalen via Billink" en "in3 keer betalen, 0% rente". in3 stond nog als Capayable Gespreid in Magento 1
- Images van payment methods in pay.nl settings worden nu via static url ingeladen.
