### PR TITLE
Updated the check when not update order status

### DIFF
--- a/includes/classes/Pay/Helper/Transaction.php
+++ b/includes/classes/Pay/Helper/Transaction.php
@@ -111,7 +111,7 @@ class Pay_Helper_Transaction
             $orderStatus = $order->get_status();
         }
 
-        if ($orderStatus == 'complete' || $orderStatus == 'processing') {
+        if ( in_array($orderStatus, array('completed','processing','shipped')) ) {
             throw new Pay_Exception_Notice('Order is already completed');
         }
 


### PR DESCRIPTION
Orders could get status failed while the order was already completed or shipped. This happen when consumer does multiple attempts and a failed status is sent to the webhook after a completed status is sent before.