### PR TITLE
Use the right key for extraction of house number

### DIFF
--- a/includes/classes/PPMFWC/Helper/Config.php
+++ b/includes/classes/PPMFWC/Helper/Config.php
@@ -82,7 +82,7 @@ class PPMFWC_Helper_Config
         $aBillingAddress = paynl_split_address($billingAddress);
 
         $_billing_house_number = $order->get_meta('_billing_house_number');
-        if (empty($aBillingAddress[1]) && !empty($_billing_house_number)) {
+        if (empty($aBillingAddress['number']) && !empty($_billing_house_number)) {
             $billingAddress = $order->get_billing_address_1() . ' ' . $_billing_house_number . $order->get_billing_address_2();
             $aBillingAddress = paynl_split_address($billingAddress);
         }
@@ -106,7 +106,7 @@ class PPMFWC_Helper_Config
         $aShippingAddress = paynl_split_address($shippingAddress);
 
         $_shipping_house_number = $order->get_meta('_shipping_house_number');
-        if (empty($aShippingAddress[1]) && !empty($_shipping_house_number)) {
+        if (empty($aShippingAddress['number']) && !empty($_shipping_house_number)) {
             $shippingAddress = $order->get_shipping_address_1() . ' ' . $_shipping_house_number . $order->get_shipping_address_2();
             $aShippingAddress = paynl_split_address($shippingAddress);
         }


### PR DESCRIPTION
We were having issues with sending double house numbers to the pay back-end in orders. This was caused by a faulty check in the getInvoiceAddress and getDeliveryAddress, it was checking for the second key instead of the allowed named keys street and number. 