### PR TITLE
Allow empty description for payment methods

### DIFF
--- a/includes/classes/PPMFWC/Gateway/Abstract.php
+++ b/includes/classes/PPMFWC/Gateway/Abstract.php
@@ -41,7 +41,6 @@ abstract class PPMFWC_Gateway_Abstract extends WC_Payment_Gateway
         $this->icon = $this->getIcon();
         $this->optionId = $this->getOptionId();
 
-        $this->has_fields         = true;
         $this->method_title       = esc_html('Pay. - ' . $this->getName());
         $this->method_description = esc_html(sprintf(__('Activate this module to accept %s transactions', PPMFWC_WOOCOMMERCE_TEXTDOMAIN), $this->getName()));
 
@@ -504,6 +503,34 @@ abstract class PPMFWC_Gateway_Abstract extends WC_Payment_Gateway
      */
     public function birthdateRequired()
     {
+        return false;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function has_fields()
+    {
+        if (trim((string) $this->get_description()) !== '') {
+            return true;
+        }
+    
+        if (!empty($this->getIssuers())) {
+            return true;
+        }
+
+        if ($this->askBirthdate()) {
+            return true;
+        }
+
+        if ($this->showVat()) {
+            return true;
+        }
+
+        if ($this->showCoc()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/includes/classes/PPMFWC/Gateway/Abstract.php
+++ b/includes/classes/PPMFWC/Gateway/Abstract.php
@@ -426,9 +426,9 @@ abstract class PPMFWC_Gateway_Abstract extends WC_Payment_Gateway
                     $pubDesc = (isset($payDefaults->brand->public_description))
                     ? $payDefaults->brand->public_description
                     : sprintf(esc_html(__('Pay with %s', PPMFWC_WOOCOMMERCE_TEXTDOMAIN)), $this->getName()); // phpcs:ignore
-                
+                    
                     $this->update_option('description', $pubDesc);
-                  }
+                }
             }
         } else {
             $this->form_fields = array(

--- a/includes/classes/PPMFWC/Gateway/Abstract.php
+++ b/includes/classes/PPMFWC/Gateway/Abstract.php
@@ -422,9 +422,14 @@ abstract class PPMFWC_Gateway_Abstract extends WC_Payment_Gateway
                 $this->set_option_default('payment_image_cached', (isset($icon)) ? $icon : '', true);
                 $this->set_option_default('min_amount', (isset($minAmount)) ? floatval($minAmount / 100) : '');
                 $this->set_option_default('max_amount', (isset($maxAmount)) ? floatval($maxAmount / 100) : '');
-
-                $pubDesc = (isset($payDefaults->brand->public_description)) ? $payDefaults->brand->public_description : sprintf(esc_html(__('Pay with %s', PPMFWC_WOOCOMMERCE_TEXTDOMAIN)), $this->getName()); // phpcs:ignore
-                $this->set_option_default('description', $pubDesc);
+                
+                if ($this->get_option('description') === 'pay_init') {
+                    $pubDesc = (isset($payDefaults->brand->public_description))
+                    ? $payDefaults->brand->public_description
+                    : sprintf(esc_html(__('Pay with %s', PPMFWC_WOOCOMMERCE_TEXTDOMAIN)), $this->getName()); // phpcs:ignore
+                
+                    $this->update_option('description', $pubDesc);
+                  }
             }
         } else {
             $this->form_fields = array(


### PR DESCRIPTION
This fixes two issues we are having:
  1. Some payment gateways did not allow saving an empty description.
     For example, `pay_gateway_creditcardsgrouped` restored the fallback description (`Pay with Credit- & Debitcards` / `Betaal met Credit- & Debitcards`)
  after saving an empty customer message.
  2. Pay. gateways rendered an empty payment box in checkout when no description or extra checkout fields were configured.

We tested it on our staging environment and everything works fine!

@woutse Please let me know if I need to do anything to get this merged/fixed